### PR TITLE
ENHANCEMENT: Added possibility to add options to settings form (and minor PHPDoc fix)

### DIFF
--- a/Form/Factory/SettingsFormFactory.php
+++ b/Form/Factory/SettingsFormFactory.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\SettingsBundle\Form\Factory;
 
+use Sylius\Bundle\SettingsBundle\Schema\SchemaFormOptionsInterface;
 use Sylius\Bundle\SettingsBundle\Schema\SchemaInterface;
 use Sylius\Component\Registry\ServiceRegistryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -48,6 +49,10 @@ final class SettingsFormFactory implements SettingsFormFactoryInterface
     {
         /** @var SchemaInterface $schema */
         $schema = $this->schemaRegistry->get($schemaAlias);
+
+        if ($schema instanceof SchemaFormOptionsInterface) {
+            $options = array_merge($schema->getOptions(), $options);
+        }
 
         $builder = $this->formFactory->createBuilder(FormType::class, $data, array_merge_recursive(
             ['data_class' => null], $options

--- a/Model/SettingsInterface.php
+++ b/Model/SettingsInterface.php
@@ -52,7 +52,7 @@ interface SettingsInterface extends ResourceInterface, \ArrayAccess, \Countable
     /**
      * @param string $name
      *
-     * @return string
+     * @return mixed
      *
      * @throws ParameterNotFoundException
      */

--- a/Schema/SchemaFormOptionsInterface.php
+++ b/Schema/SchemaFormOptionsInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\SettingsBundle\Schema;
+
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+interface SchemaFormOptionsInterface
+{
+    /**
+     * Returns options for settings form.
+     *
+     * @return array
+     */
+    public function getOptions(): array;
+}


### PR DESCRIPTION
In order to e.g. specify a default translation domain for all fields and possible sub-types it is necessary to add options to the built form.
With this change this will be easily possible.

Furthermore, one return type was wrong in PHPdoc